### PR TITLE
OCTREESTAMPED: Remove hardcoded check for "OcTree" type.

### DIFF
--- a/include/octomap_msgs/conversions.h
+++ b/include/octomap_msgs/conversions.h
@@ -70,16 +70,15 @@ namespace octomap_msgs{
    * You will need to free the memory when you're done.
    */
   static inline octomap::OcTree* binaryMsgToMap(const Octomap& msg){
-    if (msg.id != "OcTree" || !msg.binary)
+    if (!msg.binary)
       return NULL;
     
-    octomap::OcTree* octree = new octomap::OcTree(msg.resolution);    
+    octomap::OcTree* octree = new octomap::OcTree(msg.resolution);
     std::stringstream datastream;
     assert(msg.data.size() > 0);
     datastream.write((const char*) &msg.data[0], msg.data.size());
-    octree->readBinaryData(datastream);          
-    
-    return octree;      
+    octree->readBinaryData(datastream);
+    return octree;
   }
 
   // Note: binaryMsgDataToMap() deleted, potentially causes confusion 


### PR DESCRIPTION
https://github.com/OctoMap/octomap_msgs/issues/4
The check for "OcTree" id prevents the user from using derived octree types even if they only want to handle them as regular Octrees.
